### PR TITLE
Fix rename functionality bugs

### DIFF
--- a/react/src/components/Browse/CVList.js
+++ b/react/src/components/Browse/CVList.js
@@ -10,7 +10,7 @@ class CVList extends React.Component {
       const cvID = cvObject.cv_id
       const isActive = this.props.selectedCVIndex === index
       return (
-        <ListGroupItem key={cvID} active={isActive} tag="a" href="#" action onClick={() => this.props.cvClicked(index)}>
+        <ListGroupItem key={cvID} active={isActive} onClick={() => this.props.cvClicked(index)}>
           <div className="cvinfo">
             <ListGroupItemHeading>
               <CvNameForm

--- a/react/src/components/Browse/CvNameForm.js
+++ b/react/src/components/Browse/CvNameForm.js
@@ -29,7 +29,7 @@ class CvNameForm extends React.Component {
     this.props.renameConfirmed(newCVName)
     this.setState({
       editing: false,
-      value: this.props.cvName,
+      value: newCVName,
     })
   }
 


### PR DESCRIPTION
Previously rename didn't work correctly on Chrome and Firefox. Removing link-property from CV listing removed problem.